### PR TITLE
Accept null objects in deep path

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ export default function pointer(path) {
 	function partial(obj = {}, parts = []) {
 		const p = parts.shift();
 		const current = obj[p];
-		return (current === undefined || parts.length === 0) ?
+		return (current === undefined || current === null || parts.length === 0) ?
 			current : partial(current, parts);
 	}
 

--- a/test/index.js
+++ b/test/index.js
@@ -13,6 +13,8 @@ export default zora()
     t.equal(foobar('blah'), undefined);
     t.equal(foobar({foo: 'bar'}), undefined);
     t.equal(foobar({foo: {bar: 'woot'}}), 'woot');
+    t.equal(foobar({foo: null}), null);
+    t.equal(foobar({foo: {bar: null}}), null);
     const {get:foobarblah} = pointer('foo.bar.blah');
     t.equal(foobarblah({foo: {bar: {blah: 'hello'}}}), 'hello');
   })


### PR DESCRIPTION
I load objects from a backend where included objects might be null. pointer() currently throws exceptions, I would like it to handle null same as undefined